### PR TITLE
Add email validation for user creation

### DIFF
--- a/accounts/manager.py
+++ b/accounts/manager.py
@@ -4,6 +4,11 @@ class UserManager(BaseUserManager):
     use_in_migrations = True
 
     def create_user(self, email, password=None, **extra_fields):
+        """Create and save a regular user with the given email and password."""
+        if not email:
+            raise ValueError("The Email must be set")
+
+        email = self.normalize_email(email)
         user = self.model(email=email, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,8 @@
 from django.test import TestCase
+from accounts.models import User
 
-# Create your tests here.
+
+class UserManagerTests(TestCase):
+    def test_create_user_without_email_raises_error(self):
+        with self.assertRaises(ValueError):
+            User.objects.create_user(email=None, password="secret")


### PR DESCRIPTION
## Summary
- ensure `UserManager.create_user` validates email and normalizes it
- test that missing email raises `ValueError`

## Testing
- `pytest accounts/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `./manage.py test accounts.tests -v 2` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686a26946dec832098cc80bbe4b874b4